### PR TITLE
different way to loop through style content

### DIFF
--- a/deCSS3.js
+++ b/deCSS3.js
@@ -95,35 +95,33 @@ var deCSS3 = {
         };
 
     // Go through each stylesheet and return an array of new rules for each, then convert to string
-    [].forEach.call( document.styleSheets, function ( stylesheet ) {
+    [].forEach.call( document.querySelectorAll('style'), function ( stylesheet ) {
       var newRules = "",
           oldRules = "",
           stylePlaceholder = document.createElement( 'div' ),
           appendStyle = document.createElement( 'style' );
 
       // Bail if there are no styles
-      if ( ! stylesheet.cssRules ) {
+      if ( ! stylesheet.textContent ) {
         return;
       }
 
       // Find the rules we want to delete
-      [].forEach.call( stylesheet.cssRules, function ( rule, idx ) {
-        var ruleText = rule.cssText,
-            found    = ruleText.match( rFound ),
-            i, ruleSet;
+		  var ruleText = stylesheet.textContent,
+		      found    = ruleText.match( rFound ),
+		      i, ruleSet;
 
-        oldRules += ruleText;
-        newRule = ruleText;
+		  oldRules += ruleText;
+		  newRule = ruleText;
 
-        // Loop through each rule set and apply it to this css rule
-        for ( i in ruleSets ) {
-          ruleSet = ruleSets[ i ];
-          newRule = ruleReplacer( found, newRule, ruleSet.sentinel, ruleSet.regex, ruleSet.repl );
-        }
+		  // Loop through each rule set and apply it to this css rule
+		  for ( i in ruleSets ) {
+		    ruleSet = ruleSets[ i ];
+		    newRule = ruleReplacer( found, newRule, ruleSet.sentinel, ruleSet.regex, ruleSet.repl );
+		  }
 
-        // Add to rule list
-        newRules += newRule;
-      });
+      // Add to rule list
+      newRules += newRule;
 
       // Create a placeholder element to hold the old rules
       stylePlaceholder.className = 'deCSS3-Placeholder';
@@ -135,11 +133,11 @@ var deCSS3 = {
       appendStyle.textContent = newRules;
 
       // Inject the new style
-      stylesheet.ownerNode.parentNode.insertBefore( appendStyle, stylesheet.ownerNode );
+      stylesheet.parentNode.insertBefore( appendStyle, stylesheet );
       // Inject the placeholder style (to maintain order)
-      stylesheet.ownerNode.parentNode.insertBefore( stylePlaceholder, stylesheet.ownerNode );
+      stylesheet.parentNode.insertBefore( stylePlaceholder, stylesheet );
       // delete the old one
-      stylesheet.ownerNode.parentNode.removeChild( stylesheet.ownerNode );
+      stylesheet.parentNode.removeChild( stylesheet );
 
       // Just in case
       if ( stylesheet ) {


### PR DESCRIPTION
Hy,

i found a problem with stylesheet.cssRules which should be solved with my commit.

For example this code:

<pre>
.border-color {
    height: 100px;
    width: 100px;
    background-color: #fff;
    border: 2px solid rgba(50, 50, 50, 0.6);
    background-color: rgba(255, 255, 255, 0.6)
}
</pre>


stylesheet.cssRules will contain 

<pre>
.border-color {
    height: 100px;
    width: 100px;
    border: 2px solid rgba(50, 50, 50, 0.6);
    background-color: rgba(255, 255, 255, 0.6)
}
</pre>


the same code but without <pre>background-color: #fff </pre>(the fallback).

So after replacing background-color: rgba(255, 255, 255, 0.6) with rgba() there is no background-color shown at all, which is false cause older browsers will show background-color: #fff

I tested it in FF9 and Chrome 16

Thanks,
Michael
